### PR TITLE
Update example-screeps.toml to new format

### DIFF
--- a/example-screeps.toml
+++ b/example-screeps.toml
@@ -1,8 +1,13 @@
+default_deploy_mode = "upload"
+
+[upload]
 username = "your username or email"
 password = "your password"
 branch = "default"
-# optional:
 # ptr = false
 # hostname = "screeps.com"
 # ssl = true
 # port = 443
+
+# for full syntax, see
+# https://github.com/daboross/screeps-in-rust-via-wasm/blob/master/screeps-defaults.toml

--- a/example-screeps.toml
+++ b/example-screeps.toml
@@ -5,9 +5,14 @@ username = "your username or email"
 password = "your password"
 branch = "default"
 # ptr = false
+
 # hostname = "screeps.com"
 # ssl = true
 # port = 443
+
+# hostname = "localhost"
+# ssl = false
+# port = 21025
 
 # for full syntax, see
 # https://github.com/daboross/screeps-in-rust-via-wasm/blob/master/screeps-defaults.toml


### PR DESCRIPTION
This will match `cargo-screeps` 0.2 once it's released.

CC https://github.com/daboross/screeps-in-rust-via-wasm/pull/33.