### PR TITLE
Remove two lines of code unnecessary for newer stdweb

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "128"]
 use std::collections::HashSet;
 
 use log::*;
@@ -8,7 +7,6 @@ use stdweb::js;
 mod logging;
 
 fn main() {
-    stdweb::initialize();
     logging::setup_logging(logging::Info);
 
     js! {


### PR DESCRIPTION
Recursion limit was probably rendered unnecessary with the proc-macro `js!` api, and initialize is no longer needed in `stdweb` 0.4+!